### PR TITLE
AWS Bucket Region Fix

### DIFF
--- a/cloud-config/init.tpl
+++ b/cloud-config/init.tpl
@@ -35,7 +35,7 @@ runcmd:
   - corelightctl sensor deploy -v
 %{ if enrichment_enabled && cloud_provider == "aws" ~}
   - |
-    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "aws","cloud_enrichment.bucket_name": "${bucket_name}", "cloud_enrichment.bucket_region": "${bucket_region}"}' | corelightctl sensor cfg put
+    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "aws","cloud_enrichment.bucket_name": "${bucket_name}", "cloud_enrichment.bucket_location": "${bucket_region}"}' | corelightctl sensor cfg put
 %{ endif ~}
 %{ if enrichment_enabled && cloud_provider == "azure" ~}
    - |


### PR DESCRIPTION
# Description

Used the incorrect corelighctl attribute for the AWS s3 bucket region. 

`cloud_enrichment.bucket_region` -> `cloud_enrichment.bucket_location`

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?
N/A
