### PR TITLE
Bugfix: Sensor not automatically loading Cloud Enrichment Zeek scripts

### DIFF
--- a/cloud-config/init.tpl
+++ b/cloud-config/init.tpl
@@ -43,3 +43,7 @@ runcmd:
   - |
    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "gcp","cloud_enrichment.bucket_name": "${bucket_name}"}' | corelightctl sensor cfg put
 %{ endif ~}
+# TODO: Remove after Software Sensor v27.14.0 is released
+%{ if enrichment_enabled ~}
+  - /usr/local/bin/kubectl rollout restart deployment -n corelight-sensor sensor-core
+%{ endif ~}


### PR DESCRIPTION
# Description
Enabling cloud enrichment does not automatically trigger the sensor to load the enrichment zeek script. This change adds a shim to restart sensor-core after enrichment is enabled. When this is fixed in v27.14.0, this code can be removed.

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested Locally
