### PR TITLE
Monitoring Health Check Config 

### DIFF
--- a/cloud-config/init.tpl
+++ b/cloud-config/init.tpl
@@ -15,10 +15,14 @@ write_files:
         monitoring_interface:
           name: ${mon_int}
           wait: true
-%{ if mon_subnet != "" && mon_gateway != "" ~}
+%{ if health_port != "" ~}
           health_check:
             port: ${health_port}
+%{ endif ~}
+%{ if mon_subnet != "" }
             subnet: ${mon_subnet}
+%{ endif ~}
+%{ if mon_gateway != "" }
             gateway: ${mon_gateway}
 %{ endif ~}
         kubernetes:
@@ -43,7 +47,6 @@ runcmd:
   - |
    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "gcp","cloud_enrichment.bucket_name": "${bucket_name}"}' | corelightctl sensor cfg put
 %{ endif ~}
-# TODO: Remove after Software Sensor v27.14.0 is released
 %{ if enrichment_enabled ~}
   - /usr/local/bin/kubectl rollout restart deployment -n corelight-sensor sensor-core
 %{ endif ~}


### PR DESCRIPTION
# Description

In support of fixing https://github.com/corelight/terraform-aws-sensor/issues/7 this change allows for the independent configuration of the monitoring health check port without needing the subnet or gateway to also be configured.

Also removed the unnecessary comment

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with a successful deployment
