### PR TITLE
Remove Corelightctl Cloud Enrichment Configuration

### DIFF
--- a/cloud-config/init.tpl
+++ b/cloud-config/init.tpl
@@ -50,18 +50,3 @@ write_files:
 
 runcmd:
   - corelightctl sensor deploy -v
-%{ if enrichment_enabled && cloud_provider == "aws" ~}
-  - |
-    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "aws","cloud_enrichment.bucket_name": "${bucket_name}", "cloud_enrichment.bucket_location": "${bucket_region}"}' | corelightctl sensor cfg put
-%{ endif ~}
-%{ if enrichment_enabled && cloud_provider == "azure" ~}
-  - |
-    echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "azure","cloud_enrichment.bucket_name": "${bucket_name}", "cloud_enrichment.azure_storage_account": "${azure_storage_account_name}"}' | corelightctl sensor cfg put
-%{ endif ~}
-%{ if enrichment_enabled && cloud_provider == "gcp" ~}
-  - |
-   echo '{"cloud_enrichment.enable": "true", "cloud_enrichment.cloud_provider": "gcp","cloud_enrichment.bucket_name": "${bucket_name}"}' | corelightctl sensor cfg put
-%{ endif ~}
-%{ if enrichment_enabled ~}
-  - /usr/local/bin/kubectl rollout restart deployment -n corelight-sensor sensor-core
-%{ endif ~}

--- a/data.tf
+++ b/data.tf
@@ -20,13 +20,6 @@ data "cloudinit_config" "config" {
       fleet_http_proxy     = var.fleet_http_proxy
       fleet_https_proxy    = var.fleet_https_proxy
       fleet_no_proxy       = var.fleet_no_proxy
-
-      # Optional - Cloud Enrichment Configuration
-      enrichment_enabled         = var.enrichment_enabled
-      cloud_provider             = var.enrichment_cloud_provider_name
-      bucket_name                = var.enrichment_bucket_name
-      bucket_region              = var.enrichment_bucket_region
-      azure_storage_account_name = var.enrichment_storage_account_name
     })
     filename = "sensor-build.yaml"
   }

--- a/examples/deployment/main.tf
+++ b/examples/deployment/main.tf
@@ -6,17 +6,9 @@ locals {
   probe_source_ranges_cidr = ["130.211.0.0/22", "35.191.0.0/16"]
   mon_cidr                 = "10.3.0.0/24"
   mon_gateway              = "10.3.0.1"
+  fleet_token              = "b1cd099ff22ed8a41abc63929d1db126"
+  fleet_url                = "https://fleet.example.com:1443/fleet/v1/internal/softsensor/websocket"
 
-  # Optional - Fleet Manager
-  fleet_token = "b1cd099ff22ed8a41abc63929d1db126"
-  fleet_url   = "https://fleet.example.com:1443/fleet/v1/internal/softsensor/websocket"
-
-  # Optional - Enrichment Service
-  enrichment_enabled              = false # "<true | false>"
-  enrichment_cloud_provider       = "aws" # "<aws | azure | gcp>"
-  enrichment_storage_account_name = "account-foo"
-  enrichment_bucket_name          = "bucket-bar"
-  enrichment_s3_bucket_region     = "us-east-1"
 }
 
 module "sensor_config" {
@@ -33,14 +25,4 @@ module "sensor_config" {
   subnetwork_monitoring_cidr                   = local.mon_cidr
   subnetwork_monitoring_gateway                = local.mon_gateway
 
-  # Optional - Enrichment Service
-  enrichment_enabled             = local.enrichment_enabled
-  enrichment_cloud_provider_name = local.enrichment_cloud_provider
-  enrichment_bucket_name         = local.enrichment_bucket_name
-
-  # Optional - Enrichment Service Azure Only
-  enrichment_storage_account_name = local.enrichment_storage_account_name
-
-  # Optional - Enrichment Service AWS Only
-  enrichment_bucket_region = local.enrichment_s3_bucket_region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,19 +60,19 @@ variable "fleet_token" {
   type        = string
   default     = ""
   sensitive   = true
-  description = "(optional) the pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
+  description = "The pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
 }
 
 variable "fleet_url" {
   type        = string
   default     = ""
-  description = "(optional) the URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
+  description = "The URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
 }
 
 variable "fleet_server_sslname" {
   type        = string
-  default     = "1.broala.fleet.product.corelight.io"
-  description = "(optional) the SSL hostname for the fleet server"
+  default     = ""
+  description = "the SSL hostname for the fleet server"
 
 }
 
@@ -92,42 +92,4 @@ variable "fleet_no_proxy" {
   type        = string
   default     = ""
   description = "(optional) hosts or domains to bypass the proxy for fleet traffic"
-}
-
-# Enrichment Service
-variable "enrichment_enabled" {
-  description = "(optional) if cloud enrichment should enabled at time of sensor deployment"
-  type        = string
-  default     = false
-}
-
-variable "enrichment_cloud_provider_name" {
-  description = "(optional) the cloud provider name"
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = contains(["", "aws", "azure", "gcp"], var.enrichment_cloud_provider_name)
-    error_message = "allowed options: \"aws\", \"azure\", \"gcp\""
-  }
-}
-
-variable "enrichment_bucket_name" {
-  description = "(optional) the s3 bucket, azure storage container, or gcs bucket name"
-  type        = string
-  default     = ""
-}
-
-# Enrichment Service -- Azure
-variable "enrichment_storage_account_name" {
-  description = "(optional) the azure storage account where enrichment data is stored"
-  type        = string
-  default     = ""
-}
-
-# Enrichment Service -- AWS
-variable "enrichment_bucket_region" {
-  description = "(optional) the region for the s3 enrichment bucket"
-  type        = string
-  default     = ""
 }


### PR DESCRIPTION
# Description

Fleet should always be used with the Cloud Sensor and Cloud Enrichment should always be configured via Fleet. Removing corelightctl commands used to automatically configure the feature.

## Type of change
- [x] This change requires a documentation update

# How Has This Been Tested?
N/A