### PR TITLE
re-enable bumping again

### DIFF
--- a/.github/workflows/tag-bump.yml
+++ b/.github/workflows/tag-bump.yml
@@ -1,0 +1,26 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: '0'
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.75.0
+        env:
+          TAG_PREFIX: 'v'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
# Description

Re-enable auto bumping again until monorepo is complete, this way we don't have to bump this manually until then
## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions so they can be
reproduced. Please also list any relevant details for your test configuration
